### PR TITLE
Set gin-secondary-toolbar height to "auto" to accomodate site logos.

### DIFF
--- a/css/tonic.css
+++ b/css/tonic.css
@@ -21,3 +21,7 @@
     margin-top: calc(-1 * var(--gin-toolbar-y-offset));
   }
 }
+
+header.gin-secondary-toolbar {
+  height: auto;
+}


### PR DESCRIPTION
Fixes #7